### PR TITLE
Enabled php error log for php-fpm

### DIFF
--- a/modules/php/templates/fpm/pool.d/www.conf.erb
+++ b/modules/php/templates/fpm/pool.d/www.conf.erb
@@ -387,7 +387,7 @@ chdir = /
 ;                specified at startup with the -d argument
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 ;php_flag[display_errors] = off
-;php_admin_value[error_log] = /var/log/fpm-php.www.log
-;php_admin_flag[log_errors] = on
+php_admin_value[error_log] = <%= @php_error_log_path %>
+php_admin_flag[log_errors] = on
 php_admin_value[memory_limit] = <%= @memory_limit %>
 

--- a/modules/php/templates/logrotate.d/php5-fpm.erb
+++ b/modules/php/templates/logrotate.d/php5-fpm.erb
@@ -1,0 +1,26 @@
+/var/log/php5-fpm.log {
+  rotate <%= @fpm_logrotate_rotate %>
+  <%= @fpm_logrotate_when %>
+  missingok
+  notifempty
+  compress
+  delaycompress
+  postrotate
+    /usr/lib/php5/php5-fpm-reopenlogs
+  endscript
+}
+
+<%= @php_error_log_path %> {
+  rotate <%= @fpm_logrotate_rotate %>
+  <%= @fpm_logrotate_when %>
+  missingok
+  notifempty
+  compress
+  delaycompress
+  postrotate
+    /usr/bin/touch <%= @php_error_log_path %>
+    /bin/chown www-data:www-data <%= @php_error_log_path %>
+    /bin/chmod <%= @php_error_log_mode %> <%= @php_error_log_path %>
+    /usr/lib/php5/php5-fpm-reopenlogs
+  endscript
+}


### PR DESCRIPTION
- enable php workers to log
- workers log to dedicated file (otherwise, it goes to the upstart log)
- logrotate the new log file